### PR TITLE
Use forwardRef instead of ref

### DIFF
--- a/src/LoginView.js
+++ b/src/LoginView.js
@@ -139,7 +139,7 @@ export default class LoginView extends PureComponent {
         renderLoading={renderLoading}
         startInLoadingState
         onError={this.onWebViewError}
-        ref={(c) => {
+        forwardRef={(c) => {
           this.webView = c;
         }}
       />


### PR DESCRIPTION
The use of `ref` has been deprecated in functional components and `forwardRef` is introduced to solve this problem.
Here is the documentation: https://reactjs.org/docs/forwarding-refs.html